### PR TITLE
docs: specify that only the cloud API is supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 [![fern shield](https://img.shields.io/badge/%F0%9F%8C%BF-Built%20with%20Fern-brightgreen)](https://buildwithfern.com?utm_source=github&utm_medium=github&utm_campaign=readme&utm_source=https%3A%2F%2Fgithub.com%2Fbrowser-use%2Fbrowser-use-node)
 [![npm shield](https://img.shields.io/npm/v/browser-use-sdk)](https://www.npmjs.com/package/browser-use-sdk)
 
-The BrowserUse TypeScript library provides convenient access to the BrowserUse APIs from TypeScript.
+The BrowserUse TypeScript library provides convenient access to the BrowserUse Cloud APIs from TypeScript.
+It does **not** have support for local browser automation. Use the [Python library](https://github.com/browser-use/browser-use) for that.
 
 ## Three-Step QuickStart
 


### PR DESCRIPTION
No local browser automation support.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified in the README that the TypeScript SDK supports only the BrowserUse Cloud APIs. It does not support local browser automation; use the Python library for that.

<sup>Written for commit 5aa3e81e828f0b0c2123b9baa7435de323124c82. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

